### PR TITLE
Tentative fix for #227

### DIFF
--- a/public/scripts/library/sequence-model/factory.js
+++ b/public/scripts/library/sequence-model/factory.js
@@ -1548,6 +1548,8 @@ function sequenceModelFactory(BackboneModel) {
       return new this.constructor(_.omit(this.toJSON(), 'id', 'history'));
     }
 
+    sync() {}
+
     toJSON() {
 
       let attributes = super.toJSON();


### PR DESCRIPTION
This is to fix the `A "url" property or function must be specified` silent exception.

Essentially this does two things: 

1. Replaces `sync` with a noop function in the sequence model factory
2. Intercept addition and creations in the `Sequences` collection (via `Sequences#model`): the original model class is replaced by a superset of it where `#sync` has been restored.

It is slightly brutal but would potentially allow us to remove the `TemporarySequence` class (since all sequences not in the `Sequences` collection are temporary).