### PR TITLE
Tentative fix for #227

### DIFF
--- a/public/scripts/common/lib/backbone.mixed.js
+++ b/public/scripts/common/lib/backbone.mixed.js
@@ -8,6 +8,8 @@ require('backbone-deep-model');
 require('backbone.layoutmanager/backbone.layoutmanager');
 Backbone.LocalStorage = require('backbone.localstorage');
 
+Backbone.ajaxSync = _.noop();
+
 Backbone.View.prototype.parentView = function(depth) {
   var parent;
   depth = depth || 1;


### PR DESCRIPTION
This is a much less intrusive fix for #227 than #228.

Just replaces the `Backbone.ajaxSync` method with a noop function. This method gets called when saving/fetching any model not in the `Sequences` collection

Would allow us to remove `TemporarySequence` – @AJamesPhillips, thoughts?